### PR TITLE
Add npm badge to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![npm version](https://badge.fury.io/js/%40planarally%2Fdice.svg)](https://www.npmjs.com/package/@planarally/dice)
+
 # A babylon.js dice roller
 
 This repository is home to 3d dice roller functionality for the babylon.js framework using ammo.js as physics simulation.


### PR DESCRIPTION
There's no obvious link between this project and its (current) npmjs location. I've added a badge with a link to the npmjs page.